### PR TITLE
Refs: #AR-9150 fix for SDK Reference Title and intro text

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# CA PnP for wagmi
+# Chain Abstraction (Wagmi PnP)
+
+The Arcana `ca-wagmi` SDK simplifies Web3 apps built with the Wagmi library by providing a unified balance across blockchains through an easy-to-use `useBalance` modal. It also replaces the `useSendTransaction` and `useWriteContract` hooks to support chain-abstracted transactions. 
 
 ## Quick start
 


### PR DESCRIPTION
Fixes the SDK Ref (autogenerated from readme) issue of title heading.
<img width="1509" alt="Screenshot 2025-03-25 at 12 02 41 PM" src="https://github.com/user-attachments/assets/54691c9e-d103-4887-bc93-d6fd013bd25a" />
<img width="1458" alt="Screenshot 2025-03-25 at 11 26 11 AM" src="https://github.com/user-attachments/assets/1de8177e-a058-46fd-9b52-adce4c57243c" />

